### PR TITLE
Added support for `website` and `export` commands with initial support for exporting GitHub labels as a `json` file

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,4 @@
+import repolabels
+
+if __name__ == "__main__":
+    repolabels.main()

--- a/exceptions/extractor_exceptions.py
+++ b/exceptions/extractor_exceptions.py
@@ -1,0 +1,8 @@
+"""
+This module contains the exceptions that are used by extractors.
+"""
+
+
+class SiteNotSupported(Exception):
+    def __init__(self, hostname):
+        self.message = f"SiteNotSupported: {hostname} Repository host not supported."

--- a/extractors/base_extractor.py
+++ b/extractors/base_extractor.py
@@ -1,0 +1,19 @@
+"""
+This module contains the BaseExtractor Abstract class which all other extractors are inherited from.
+"""
+from abc import ABC, abstractmethod
+
+
+class BaseExtractor(ABC):
+
+    def __init__(self, link):
+        self.link = link
+        self.labels = set()
+
+    @abstractmethod
+    def request_labels(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def execute(self):
+        raise NotImplementedError

--- a/extractors/github_extractor.py
+++ b/extractors/github_extractor.py
@@ -1,0 +1,107 @@
+"""
+This module contains the extractor for GitHub.
+GitHub: https://github.com/
+"""
+
+import json
+import os
+import aiohttp
+import asyncio
+import logging
+
+from bs4 import BeautifulSoup
+from extractors.base_extractor import BaseExtractor
+from urllib.parse import urlparse
+from itertools import chain
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubExtractor(BaseExtractor):
+
+    def __init__(self, link):
+        super().__init__(link)
+        self.main_api_link = 'https://api.github.com'
+        self.accept_header = 'application/vnd.github.v3+json'
+        # Max number of pages allowed by GitHub API for list of labels in repository is 100
+        # https://docs.github.com/en/rest/reference/issues#list-labels-for-a-repository
+        self.per_page = 100
+        self.repo_owner, self.repo_name = self.parse_github_link(link)
+        self.labels_api_link = f'{self.main_api_link}/repos/{self.repo_owner}/{self.repo_name}/labels'
+        self.labels_encountered = set()
+
+    @staticmethod
+    def parse_github_link(link):
+        parsed_url_path = urlparse(link).path.split('/')
+        repo_owner = parsed_url_path[1]
+        repo_name = parsed_url_path[2]
+        return repo_owner, repo_name
+
+    def gen_custom_labels_list(self, list_of_label_dict):
+        custom_labels_list = []
+        for current_label_dict in list_of_label_dict:
+            constructed_dict = {
+                **current_label_dict
+            }
+            del constructed_dict['id']
+            del constructed_dict['node_id']
+            del constructed_dict['url']
+            del constructed_dict['default']
+            self.labels_encountered.add(constructed_dict['name'])
+            custom_labels_list.append(constructed_dict)
+        return custom_labels_list
+
+    async def get_num_of_pages(self, session):
+        non_api_link_to_labels = f'{self.link}/labels'
+        async with session.get(non_api_link_to_labels, headers={"Accept": "text/html"}) as response:
+            html = await response.text()
+            soup = BeautifulSoup(html, 'html.parser')
+            num_of_labels = int(soup.select('div.labels-list span.js-labels-count', limit=1)[0].contents[0])
+            num_of_pages = (num_of_labels // self.per_page) + (1 if num_of_labels % self.per_page != 0 else 0)
+            logger.debug(f'{self.link} has {num_of_pages} pages.')
+            return num_of_pages
+
+    async def get_labels_list(self, session, request_params):
+        """
+        Returns the list of labels with customised properties based on the list of labels retrieved from the GitHub API
+        :param session: The session object
+        :param request_params: The request_params which should contain the per_page and page params
+        :return: The list of labels with customised properties.
+        """
+        async with session.get(self.labels_api_link, params=request_params) as response:
+            logger.debug(f'get_labels method page request information {response.request_info}')
+            current_labels = await response.json()
+            logger.debug(f'labels list json {json.dumps(current_labels)}')
+            return self.gen_custom_labels_list(current_labels)
+
+    async def request_labels(self):
+        api_headers = {'Accept': self.accept_header}
+        params = {'per_page': self.per_page}
+        async with aiohttp.ClientSession(headers=api_headers) as session:
+            num_of_pages = await self.get_num_of_pages(session)
+            tasks = []
+            for current_page_num in range(1, num_of_pages + 1):
+                params['page'] = current_page_num
+                tasks.append(asyncio.ensure_future(self.get_labels_list(session, params)))
+
+            custom_json_list_labels = await asyncio.gather(*tasks)
+            # To flatten the lists
+            custom_json_list_labels = list(chain.from_iterable(custom_json_list_labels))
+            logger.debug(custom_json_list_labels)
+            return custom_json_list_labels
+
+    def execute(self):
+        # Workaround for known issue involving event loop for Windows environment:
+        # Resources:
+        # https://github.com/aio-libs/aiohttp/issues/4536#issuecomment-698441077
+        # https://bugs.python.org/issue39232 (Known issue in Python)
+        if os.name == "nt":
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        custom_json_list_labels = asyncio.run(self.request_labels())
+
+        logger.debug(json.dumps(custom_json_list_labels))
+        logger.debug(len(custom_json_list_labels))
+
+        # To export the json file and prettify it.
+        with open('exported.json', mode='w') as json_file:
+            json.dump(custom_json_list_labels, json_file, indent=4)

--- a/repolabels.py
+++ b/repolabels.py
@@ -1,0 +1,53 @@
+"""
+This module contains the main command line interface.
+"""
+
+import argparse
+import sys
+import logging
+
+from utilities.cli_utils import open_link, run_extractor, remove_trailing_slash_to_url
+
+SOFTWARE_NAME = "Repository Labels command line interface"
+VERSION = '1.0.0'
+MAIN_PROJECT_REPO_LINK = "https://github.com/JonathanLeeWH/repo-labels-cli"
+
+logging.basicConfig(filename='repolabels.log', filemode='w', level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=f'{SOFTWARE_NAME} is a command line interface to manage GitHub Repository labels.')
+
+    subparsers = parser.add_subparsers(description="A list of possible subcommands")
+
+    # Parser for "export" subcommand
+    parser_export = subparsers.add_parser('export',
+                                          help="Exports labels from the repository in a compatible format "
+                                               "as a json file.")
+    parser_export.add_argument('export_repo_link', help="Link to the repository in which the labels are exported from.")
+
+    # Parser for "website" subcommand
+    parser_website = subparsers.add_parser('website', help=f'Redirects to the {SOFTWARE_NAME} project website')
+    parser_website.set_defaults(func=open_link,
+                                url=MAIN_PROJECT_REPO_LINK)
+
+    args = parser.parse_args()
+
+    logger.info("Start executing script")
+
+    if hasattr(args, 'func'):
+        args.func(args)
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+
+    if hasattr(args, 'export_repo_link'):
+        run_extractor(remove_trailing_slash_to_url(args.export_repo_link))
+
+    logger.info("Script execution completed")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+aiohttp==3.7.4.post0
+async-timeout==3.0.1
+attrs==21.2.0
+beautifulsoup4==4.9.3
+chardet==4.0.0
+idna==3.2
+multidict==5.1.0
+soupsieve==2.2.1
+typing-extensions==3.10.0.0
+yarl==1.6.3

--- a/utilities/cli_utils.py
+++ b/utilities/cli_utils.py
@@ -1,0 +1,28 @@
+"""
+This module contains the command line interface (cli) utility methods
+"""
+
+import webbrowser
+
+from utilities.extractor_facade import ExtractorFacade
+
+
+def open_link(args):
+    webbrowser.open(args.url, new=2)
+
+
+def remove_trailing_slash_to_url(url):
+    """
+    Returns the input url without any trailing / if it had a trailing slash. This is useful for repository url
+    where https://github.com/JonathanLeeWH/myrepo/ and https://github.com/JonathanLeeWH/myrepo both are equivalent
+    hence for consistency we remove the trailing / for repository url
+    :param url: The url to be formatted
+    :return: Returns the url without any trailing /
+    """
+
+    return url[:-1] if url[-1] == '/' else url
+
+
+def run_extractor(export_repo_link):
+    response = ExtractorFacade().execute(export_repo_link)
+    return response

--- a/utilities/extractor_facade.py
+++ b/utilities/extractor_facade.py
@@ -1,0 +1,33 @@
+"""
+This module contains the ExtractorFacade which calls the appropriate method from the appropriate classes
+based on the parameter passed.
+"""
+
+import logging
+
+from urllib.parse import urlparse
+from exceptions.extractor_exceptions import SiteNotSupported
+from extractors.github_extractor import GitHubExtractor
+
+logger = logging.getLogger(__name__)
+
+
+class ExtractorFacade:
+
+    @staticmethod
+    def execute(repo_link: str):
+        try:
+            parsed_url = urlparse(repo_link)
+            hostname = parsed_url.netloc
+
+            # To consider the case where the url does not have a scheme such as github.com without https prepended
+            if not parsed_url.scheme:
+                parsed_url = urlparse(f'https://{repo_link}')
+                hostname = parsed_url.netloc
+
+            if "github.com" in hostname:
+                GitHubExtractor(repo_link).execute()
+            else:
+                raise SiteNotSupported(hostname)
+        except SiteNotSupported as error:
+            logger.error(error.message)


### PR DESCRIPTION
- Added support for `website` and `export` commands with initial support for exporting `GitHub` labels as a `json` file
- Added `requirements.txt` with list of package dependencies

**Note**: The exported json file is a customised version of the `json` response from `GitHub API` so as to be compatible with future enhancements such as importing the labels to a different GitHub repository