### PR TITLE
Refactored execute method in `github_extractor.py` and include the documentation for the function

### DIFF
--- a/extractors/github_extractor.py
+++ b/extractors/github_extractor.py
@@ -91,6 +91,12 @@ class GitHubExtractor(BaseExtractor):
             return custom_json_list_labels
 
     def execute(self):
+        """
+        This is the main function which will be executed to run the GitHub extractor.
+        It returns the list of labels with customised properties compatible with this command line interface.
+        :return: It returns the list of labels with customised properties compatible with this command line interface
+        """
+
         # Workaround for known issue involving event loop for Windows environment:
         # Resources:
         # https://github.com/aio-libs/aiohttp/issues/4536#issuecomment-698441077
@@ -102,6 +108,4 @@ class GitHubExtractor(BaseExtractor):
         logger.debug(json.dumps(custom_json_list_labels))
         logger.debug(len(custom_json_list_labels))
 
-        # To export the json file and prettify it.
-        with open('exported.json', mode='w') as json_file:
-            json.dump(custom_json_list_labels, json_file, indent=4)
+        return custom_json_list_labels

--- a/repolabels.py
+++ b/repolabels.py
@@ -3,6 +3,7 @@ This module contains the main command line interface.
 """
 
 import argparse
+import json
 import sys
 import logging
 
@@ -26,7 +27,7 @@ def main():
     parser_export = subparsers.add_parser('export',
                                           help="Exports labels from the repository in a compatible format "
                                                "as a json file.")
-    parser_export.add_argument('export_repo_link', help="Link to the repository in which the labels are exported from.")
+    parser_export.add_argument('export_cmd_repo_link', help="Link to the repository in which the labels are exported from.")
 
     # Parser for "website" subcommand
     parser_website = subparsers.add_parser('website', help=f'Redirects to the {SOFTWARE_NAME} project website')
@@ -43,8 +44,14 @@ def main():
     if len(sys.argv) == 1:
         parser.print_help()
 
-    if hasattr(args, 'export_repo_link'):
-        run_extractor(remove_trailing_slash_to_url(args.export_repo_link))
+    # The logic for "export" subcommand
+    if hasattr(args, 'export_cmd_repo_link'):
+        file_path = 'exported.json'
+        custom_json_list_labels = run_extractor(remove_trailing_slash_to_url(args.export_cmd_repo_link))
+        # To export the json file and prettify it.
+        with open(file_path, mode='w') as json_file:
+            json.dump(custom_json_list_labels, json_file, indent=4)
+        logger.info(f'Labels from {args.export_cmd_repo_link} exported to {file_path}')
 
     logger.info("Script execution completed")
 

--- a/repolabels.py
+++ b/repolabels.py
@@ -7,11 +7,14 @@ import json
 import sys
 import logging
 
+from pathlib import Path
 from utilities.cli_utils import open_link, run_extractor, remove_trailing_slash_to_url
 
 SOFTWARE_NAME = "Repository Labels command line interface"
 VERSION = '1.0.0'
 MAIN_PROJECT_REPO_LINK = "https://github.com/JonathanLeeWH/repo-labels-cli"
+MAIN_EXPORT_DIRECTORY = Path.cwd().joinpath('exported')
+DEFAULT_EXPORT_FILE_NAME = 'exported.json'
 
 logging.basicConfig(filename='repolabels.log', filemode='w', level=logging.DEBUG)
 logger = logging.getLogger(__name__)
@@ -20,6 +23,7 @@ logger = logging.getLogger(__name__)
 def main():
     parser = argparse.ArgumentParser(
         description=f'{SOFTWARE_NAME} is a command line interface to manage GitHub Repository labels.')
+    parser.add_argument('--version', action='version', version=f'{SOFTWARE_NAME} Version {VERSION}')
 
     subparsers = parser.add_subparsers(description="A list of possible subcommands")
 
@@ -27,7 +31,13 @@ def main():
     parser_export = subparsers.add_parser('export',
                                           help="Exports labels from the repository in a compatible format "
                                                "as a json file.")
-    parser_export.add_argument('export_cmd_repo_link', help="Link to the repository in which the labels are exported from.")
+    parser_export.add_argument('export_cmd_repo_link',
+                               help="Link to the repository in which the labels are exported from.")
+    parser_export.add_argument('-d', '--dest_file_path',
+                               default=MAIN_EXPORT_DIRECTORY.joinpath(DEFAULT_EXPORT_FILE_NAME),
+                               type=Path,
+                               help="The destination file path in which the exported labels will be exported to. "
+                                    "(default destination file path: 'exported/exported.json')")
 
     # Parser for "website" subcommand
     parser_website = subparsers.add_parser('website', help=f'Redirects to the {SOFTWARE_NAME} project website')
@@ -46,8 +56,9 @@ def main():
 
     # The logic for "export" subcommand
     if hasattr(args, 'export_cmd_repo_link'):
-        file_path = 'exported.json'
+        file_path = args.dest_file_path.with_suffix('.json')
         custom_json_list_labels = run_extractor(remove_trailing_slash_to_url(args.export_cmd_repo_link))
+        file_path.parent.mkdir(parents=True, exist_ok=True)
         # To export the json file and prettify it.
         with open(file_path, mode='w') as json_file:
             json.dump(custom_json_list_labels, json_file, indent=4)

--- a/repolabels.py
+++ b/repolabels.py
@@ -16,7 +16,14 @@ MAIN_PROJECT_REPO_LINK = "https://github.com/JonathanLeeWH/repo-labels-cli"
 MAIN_EXPORT_DIRECTORY = Path.cwd().joinpath('exported')
 DEFAULT_EXPORT_FILE_NAME = 'exported.json'
 
-logging.basicConfig(filename='repolabels.log', filemode='w', level=logging.DEBUG)
+debug_mode = False
+
+# noinspection PyArgumentList
+# Known Pycharm issue: https://youtrack.jetbrains.com/issue/PY-39762
+logging.basicConfig(level=logging.DEBUG if debug_mode else logging.INFO,
+                    format="%(asctime)s %(name)s %(funcName)s [%(levelname)s] %(message)s"
+                    if debug_mode else "%(asctime)s [%(levelname)s] %(message)s",
+                    handlers=[logging.FileHandler('repolabels.log', mode='w'), logging.StreamHandler(sys.stdout)])
 logger = logging.getLogger(__name__)
 
 
@@ -57,7 +64,7 @@ def main():
     # The logic for "export" subcommand
     if hasattr(args, 'export_cmd_repo_link'):
         file_path = args.dest_file_path.with_suffix('.json')
-        custom_json_list_labels = run_extractor(remove_trailing_slash_to_url(args.export_cmd_repo_link))
+        custom_json_list_labels = run_extractor(remove_trailing_slash_to_url(args.export_cmd_repo_link)).execute()
         file_path.parent.mkdir(parents=True, exist_ok=True)
         # To export the json file and prettify it.
         with open(file_path, mode='w') as json_file:

--- a/repolabels.py
+++ b/repolabels.py
@@ -4,16 +4,21 @@ This module contains the main command line interface.
 
 import argparse
 import json
+import re
 import sys
 import logging
 
 from pathlib import Path
+from urllib.parse import urlparse
 from utilities.cli_utils import open_link, run_extractor, remove_trailing_slash_to_url
+from datetime import datetime
 
 SOFTWARE_NAME = "Repository Labels command line interface"
 VERSION = '1.0.0'
-MAIN_PROJECT_REPO_LINK = "https://github.com/JonathanLeeWH/repo-labels-cli"
+MAIN_PROJECT_REPO_LINK = "https://github.com/lwhjon/repo-labels-cli"
 MAIN_EXPORT_DIRECTORY = Path.cwd().joinpath('exported')
+# The default file name will be renamed to the format {repo_owner}_{repo_name}_{current date and time}.json
+# if the default: exported/exported.json is used.
 DEFAULT_EXPORT_FILE_NAME = 'exported.json'
 
 debug_mode = False
@@ -44,7 +49,8 @@ def main():
                                default=MAIN_EXPORT_DIRECTORY.joinpath(DEFAULT_EXPORT_FILE_NAME),
                                type=Path,
                                help="The destination file path in which the exported labels will be exported to. "
-                                    "(default destination file path: 'exported/exported.json')")
+                                    "(default destination file path: "
+                                    "'exported/{repo_owner}_{repo_name}_{current date and time}.json')")
 
     # Parser for "website" subcommand
     parser_website = subparsers.add_parser('website', help=f'Redirects to the {SOFTWARE_NAME} project website')
@@ -63,8 +69,26 @@ def main():
 
     # The logic for "export" subcommand
     if hasattr(args, 'export_cmd_repo_link'):
+        current_export_url = remove_trailing_slash_to_url(args.export_cmd_repo_link)
+        parsed_export_url = urlparse(current_export_url)
+
+        # To consider the case where the url does not have a scheme such as github.com without https prepended
+        if not parsed_export_url.scheme:
+            current_export_url = f'https://{current_export_url}'
+            parsed_export_url = urlparse(current_export_url)
+
+        _, repo_owner, repo_name = parsed_export_url.path.split('/')
+
         file_path = args.dest_file_path.with_suffix('.json')
-        current_extractor = run_extractor(remove_trailing_slash_to_url(args.export_cmd_repo_link))
+
+        # If the default directory file path is used,
+        # rename the file_path to the format: 'exported/{repo_owner}_{repo_name}_{current date and time}.json'
+        if args.dest_file_path == MAIN_EXPORT_DIRECTORY.joinpath(DEFAULT_EXPORT_FILE_NAME):
+            file_path = MAIN_EXPORT_DIRECTORY.joinpath(
+                f"{repo_owner}_{repo_name}_{re.sub(r'[-.:]', '_', str(datetime.now()))}.json")
+
+        current_extractor = run_extractor(current_export_url)
+
         if current_extractor:
             custom_json_list_labels = current_extractor.execute()
             file_path.parent.mkdir(parents=True, exist_ok=True)

--- a/utilities/extractor_facade.py
+++ b/utilities/extractor_facade.py
@@ -26,8 +26,9 @@ class ExtractorFacade:
                 hostname = parsed_url.netloc
 
             if "github.com" in hostname:
-                GitHubExtractor(repo_link).execute()
+                return GitHubExtractor(repo_link).execute()
             else:
                 raise SiteNotSupported(hostname)
         except SiteNotSupported as error:
             logger.error(error.message)
+        return None

--- a/utilities/extractor_facade.py
+++ b/utilities/extractor_facade.py
@@ -26,7 +26,7 @@ class ExtractorFacade:
                 hostname = parsed_url.netloc
 
             if "github.com" in hostname:
-                return GitHubExtractor(repo_link).execute()
+                return GitHubExtractor(repo_link)
             else:
                 raise SiteNotSupported(hostname)
         except SiteNotSupported as error:


### PR DESCRIPTION
- Refactored execute method in `github_extractor.py` and include the documentation for the function to improve method cohesion as well as adopt polymorphism
- Added support for `export` subcommand `-d` or `--dest_file_path` flags to support custom file path
- Added support for `--version` flag
- Amended logging logic with custom format and displaying to standard out and log file
- Improved Security PR #5 #8 (Resolved `incomplete url substring sanitization` vulnerability)
- Amended `export` subcommand logic such that if the `default directory file path` is used, the `exported file path` will be of the format `exported/{repo_owner}_{repo_name}_{current date and time}.json`
- Amended `MAIN_PROJECT_REPO_LINK` to the correct repository link