### PR TITLE
Amended `export` subcommand `json` format and added `.env` file support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# GitHub credentials
+# Please refer to our documentation or GitHub documentation on how to retrieve your GitHub Personal Access Token.
+# Resources:
+# https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token
+GITHUB_USERNAME=YOUR_GITHUB_USERNAME
+GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PERSONAL_ACCESS_TOKEN

--- a/extractors/base_extractor.py
+++ b/extractors/base_extractor.py
@@ -8,7 +8,6 @@ class BaseExtractor(ABC):
 
     def __init__(self, link):
         self.link = link
-        self.labels = set()
         self.repo_owner = None
         self.repo_name = None
 

--- a/extractors/github_extractor.py
+++ b/extractors/github_extractor.py
@@ -9,10 +9,11 @@ import aiohttp
 import asyncio
 import logging
 
+from aiohttp import BasicAuth
 from bs4 import BeautifulSoup
 from extractors.base_extractor import BaseExtractor
+from utilities.config import GITHUB_USERNAME, GITHUB_PERSONAL_ACCESS_TOKEN
 from urllib.parse import urlparse
-from itertools import chain
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ class GitHubExtractor(BaseExtractor):
         self.per_page = 100
         self.repo_owner, self.repo_name = self.parse_github_link(link)
         self.labels_api_link = f'{self.main_api_link}/repos/{self.repo_owner}/{self.repo_name}/labels'
-        self.labels_encountered = set()
+        self.authentication = BasicAuth(GITHUB_USERNAME, password=GITHUB_PERSONAL_ACCESS_TOKEN)
 
     @staticmethod
     def parse_github_link(link):
@@ -37,21 +38,22 @@ class GitHubExtractor(BaseExtractor):
         repo_name = parsed_url_path[2]
         return repo_owner, repo_name
 
-    def gen_custom_labels_list(self, list_of_label_dict):
-        custom_labels_list = []
+    @staticmethod
+    def gen_custom_labels_dict(list_of_label_dict):
+        custom_labels_dict = dict()
         for current_label_dict in list_of_label_dict:
-            constructed_dict = {
+            current_label_name = current_label_dict['name'].lower()
+            custom_labels_dict[current_label_name] = {
                 **current_label_dict
             }
-            del constructed_dict['id']
-            del constructed_dict['node_id']
-            del constructed_dict['url']
-            del constructed_dict['default']
-            self.labels_encountered.add(constructed_dict['name'])
-            custom_labels_list.append(constructed_dict)
-        return custom_labels_list
+            del custom_labels_dict[current_label_name]['id']
+            del custom_labels_dict[current_label_name]['node_id']
+            del custom_labels_dict[current_label_name]['url']
+            del custom_labels_dict[current_label_name]['default']
+        return custom_labels_dict
 
     async def get_num_of_pages(self, session):
+        # TODO: Add support for private repository
         non_api_link_to_labels = f'{self.link}/labels'
         async with session.get(non_api_link_to_labels, headers={"Accept": "text/html"}) as response:
             html = await response.text()
@@ -61,39 +63,46 @@ class GitHubExtractor(BaseExtractor):
             logger.debug(f'{self.link} has {num_of_pages} pages.')
             return num_of_pages
 
-    async def get_labels_list(self, session, request_params):
+    async def get_labels_dict(self, session, request_params):
         """
-        Returns the list of labels with customised properties based on the list of labels retrieved from the GitHub API
+        Returns a dictionary of labels with customised properties based on the list of labels retrieved from the
+        GitHub API
         :param session: The session object
         :param request_params: The request_params which should contain the per_page and page params
-        :return: The list of labels with customised properties.
+        :return: Returns a dictionary of labels with customised properties.
         """
         async with session.get(self.labels_api_link, params=request_params) as response:
             logger.debug(f'get_labels method page request information {response.request_info}')
             current_labels = await response.json()
-            logger.debug(f'labels list json {json.dumps(current_labels)}')
-            return self.gen_custom_labels_list(current_labels)
+            logger.debug(f'labels list json from GitHub API: {json.dumps(current_labels)}')
+            return self.gen_custom_labels_dict(current_labels)
 
     async def request_labels(self):
         api_headers = {'Accept': self.accept_header}
-        async with aiohttp.ClientSession(headers=api_headers) as session:
+        async with aiohttp.ClientSession(headers=api_headers, auth=self.authentication) as session:
             num_of_pages = await self.get_num_of_pages(session)
             tasks = []
             for current_page_num in range(1, num_of_pages + 1):
                 params = {'per_page': self.per_page, 'page': current_page_num}
-                tasks.append(asyncio.ensure_future(self.get_labels_list(session, params)))
-
+                tasks.append(asyncio.ensure_future(self.get_labels_dict(session, params)))
             custom_json_list_labels = await asyncio.gather(*tasks)
-            # To flatten the lists
-            custom_json_list_labels = list(chain.from_iterable(custom_json_list_labels))
             logger.debug(custom_json_list_labels)
-            return custom_json_list_labels
+
+            # To convert to the list to a dictionary (custom format json compatible with this command line interface)
+            custom_labels_dict_json = dict()
+            for current_dict in custom_json_list_labels:
+                logger.debug(current_dict)
+                custom_labels_dict_json.update(current_dict)
+
+            logger.debug(custom_labels_dict_json)
+            return custom_labels_dict_json
 
     def execute(self):
         """
         This is the main function which will be executed to run the GitHub extractor.
-        It returns the list of labels with customised properties compatible with this command line interface.
-        :return: It returns the list of labels with customised properties compatible with this command line interface
+        It returns a dictionary of labels with customised properties compatible with this command line interface.
+        :return: It returns a dictionary of labels with customised properties compatible
+        with this command line interface
         """
 
         # Workaround for known issue involving event loop for Windows environment:
@@ -102,9 +111,9 @@ class GitHubExtractor(BaseExtractor):
         # https://bugs.python.org/issue39232 (Known issue in Python)
         if os.name == "nt":
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-        custom_json_list_labels = asyncio.run(self.request_labels())
+        custom_labels_dict_json = asyncio.run(self.request_labels())
+        logger.debug(custom_labels_dict_json)
+        logger.debug(json.dumps(custom_labels_dict_json))
+        logger.debug(len(custom_labels_dict_json.keys()))
 
-        logger.debug(json.dumps(custom_json_list_labels))
-        logger.debug(len(custom_json_list_labels))
-
-        return custom_json_list_labels
+        return custom_labels_dict_json

--- a/repolabels.py
+++ b/repolabels.py
@@ -91,11 +91,11 @@ def main():
                 file_path = MAIN_EXPORT_DIRECTORY.joinpath(
                     f"{repo_owner}_{repo_name}_{re.sub(r'[-.: ]', '_', str(datetime.now()))}.json")
 
-            custom_json_list_labels = current_extractor.execute()
+            custom_labels_dict_json = current_extractor.execute()
             file_path.parent.mkdir(parents=True, exist_ok=True)
             # To export the json file and prettify it.
             with open(file_path, mode='w') as json_file:
-                json.dump(custom_json_list_labels, json_file, indent=4)
+                json.dump(custom_labels_dict_json, json_file, indent=4)
             logger.info(f'Labels from {args.export_cmd_repo_link} exported to {file_path}')
 
     # The logic for "import" subcommand with source json file path

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ beautifulsoup4==4.9.3
 chardet==4.0.0
 idna==3.2
 multidict==5.1.0
+python-dotenv==0.18.0
 soupsieve==2.2.1
 typing-extensions==3.10.0.0
 yarl==1.6.3

--- a/utilities/config.py
+++ b/utilities/config.py
@@ -1,0 +1,13 @@
+"""
+This module handles environmental variables
+"""
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# GitHub credentials
+GITHUB_USERNAME = os.getenv('GITHUB_USERNAME')
+GITHUB_PERSONAL_ACCESS_TOKEN = os.getenv('GITHUB_PERSONAL_ACCESS_TOKEN')


### PR DESCRIPTION
- Amended `export` subcommand `json` format and added `.env` file support
- Amended export json format that is compatible with this command line interface
**Note**: This is to take advantage of hashing in Python's `dict` build in implementation to optimised lookup operations when implementing the `import` subcommand in future commits
- Added support for `.env` files
- Added `.env.example` file which provide a sample of the environmental variables that should be included in the `.env` file.
- Amended `requirements.txt` to include new package dependencies
- Added support for `GitHub Personal Access Token` authentication support in `github_extractor.py`