### PR TITLE
Added `import` subcommand core logic with support for importing labels to repository from a compatible `json` file

### DIFF
--- a/importers/base_importer.py
+++ b/importers/base_importer.py
@@ -10,7 +10,6 @@ class BaseImporter(ABC):
     def __init__(self, link, src_json_file_path: Path = None):
         self.link = link
         self.src_json_file_path = src_json_file_path
-        self.labels = set()
         self.repo_owner = None
         self.repo_name = None
 

--- a/importers/github_importer.py
+++ b/importers/github_importer.py
@@ -3,9 +3,16 @@ This module contains the importer for GitHub.
 GitHub: https://github.com/
 """
 
+import asyncio
+import json
 import logging
+import os
+import aiohttp
 
+from aiohttp import BasicAuth
+from extractors.github_extractor import GitHubExtractor
 from importers.base_importer import BaseImporter
+from utilities.config import GITHUB_USERNAME, GITHUB_PERSONAL_ACCESS_TOKEN
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -15,14 +22,83 @@ class GitHubImporter(BaseImporter):
 
     def __init__(self, link, src_json_file_path: Path = None):
         super().__init__(link, src_json_file_path)
+        self.main_api_link = 'https://api.github.com'
+        self.accept_header = 'application/vnd.github.v3+json'
+        self.repo_owner, self.repo_name = GitHubExtractor.parse_github_link(link)
+        self.labels_api_link = f'{self.main_api_link}/repos/{self.repo_owner}/{self.repo_name}/labels'
+        self.existing_labels_json = None
+        self.json_data = None
+        self.labels_encountered = set()
+        self.authentication = BasicAuth(GITHUB_USERNAME, password=GITHUB_PERSONAL_ACCESS_TOKEN)
 
-    def import_labels(self):
-        pass
+    async def create_label(self, session, properties):
+        async with session.post(self.labels_api_link, json=properties) as response:
+            logger.debug(response.request_info)
+            result = await response.json()
+            logger.debug(result)
+            return result
+
+    async def update_label(self, session, label_name, new_properties):
+        async with session.patch(f'{self.labels_api_link}/{label_name}', json=new_properties) as response:
+            logger.debug(response.request_info)
+            result = await response.json()
+            logger.debug(result)
+            return result
+
+    async def delete_label(self, session, label_name):
+        async with session.delete(f'{self.labels_api_link}/{label_name}') as response:
+            logger.debug(response.request_info)
+            return True
+
+    async def import_labels(self):
+        api_headers = {'Accept': self.accept_header}
+        async with aiohttp.ClientSession(headers=api_headers, auth=self.authentication) as session:
+            tasks = []
+            for current_label_name in self.json_data.keys():
+                self.labels_encountered.add(current_label_name)
+                if current_label_name in self.existing_labels_json.keys():
+                    # Optimisation: If the label and its properties in the repository are identical to the json file,
+                    # there will not be any API calls. This is to reduce unnecessary API calls.
+                    if self.json_data[current_label_name] == self.existing_labels_json[current_label_name]:
+                        continue
+                    else:
+                        json_properties = self.json_data[current_label_name]
+                        new_properties = {
+                            **json_properties
+                        }
+                        new_properties['new_name'] = new_properties['name']
+                        del new_properties['name']
+                        await self.update_label(session, self.existing_labels_json[current_label_name]['name'],
+                                                new_properties)
+                else:
+                    await self.create_label(session, self.json_data[current_label_name])
+
+            labels_not_in_json = set(self.existing_labels_json.keys()).difference(self.labels_encountered)
+            for current_label_name in labels_not_in_json:
+                await self.delete_label(session, self.existing_labels_json[current_label_name]['name'])
 
     def execute(self):
+        """
+        This is the main function which will be executed to run the GitHub importer.
+        :return: It returns True if import is successful and false if it is not successful.
+        """
         if self.src_json_file_path:
             # Import the labels from a source json file path
-            pass
+            with open(self.src_json_file_path, mode='r') as json_file:
+                self.json_data = json.load(json_file)
+                logger.debug("The data read from json file:", self.json_data)
+
+                extractor = GitHubExtractor(self.link)
+                self.existing_labels_json = extractor.execute()
+                logger.debug(self.existing_labels_json)
+
+                # Workaround for known issue involving event loop for Windows environment:
+                # Resources:
+                # https://github.com/aio-libs/aiohttp/issues/4536#issuecomment-698441077
+                # https://bugs.python.org/issue39232 (Known issue in Python)
+                if os.name == "nt":
+                    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+                asyncio.run(self.import_labels())
         else:
             # TODO: Import the labels from a source repository url
             raise NotImplementedError


### PR DESCRIPTION
- Added `import` subcommand core logic with support for importing labels to repository from a compatible `json` file
- Added support for private repositories in `export` subcommand
- Optimised API call logic in `github_extractor.py`'s `request_labels` function
- Added comments for `github_extractor.py`'s `get_num_of_pages` function which is currently not in used with its benefits and current limitations.
**Note**: It is currently in consideration whether `github_extractor.py`'s `get_num_of_pages` function should be removed in future commits. If it is removed in future commits, `beautifulsoup4` package dependencies would also be removed as it would no longer be in used