### PR TITLE
Added `sync` subcommand to allow syncing of labels from source repository to destination repository and optimised importing of `GitHub` labels logic in `github_importer.py` through concurrency

### DIFF
--- a/importers/base_importer.py
+++ b/importers/base_importer.py
@@ -2,14 +2,13 @@
 This module contains the BaseImporter Abstract class which all other importers are inherited from.
 """
 from abc import ABC, abstractmethod
-from pathlib import Path
 
 
 class BaseImporter(ABC):
 
-    def __init__(self, link, src_json_file_path: Path = None):
+    def __init__(self, link, loaded_json_data):
         self.link = link
-        self.src_json_file_path = src_json_file_path
+        self.json_data = loaded_json_data
         self.repo_owner = None
         self.repo_name = None
 

--- a/utilities/importer_facade.py
+++ b/utilities/importer_facade.py
@@ -4,7 +4,6 @@ based on the parameter passed.
 """
 
 import logging
-from pathlib import Path
 
 from urllib.parse import urlparse
 from exceptions.general_exceptions import SiteNotSupported
@@ -16,14 +15,14 @@ logger = logging.getLogger(__name__)
 class ImporterFacade:
 
     @staticmethod
-    def execute(repo_link: str, src_json_file_path: Path = None):
+    def execute(repo_link: str, loaded_json_data):
         try:
             current_repo_link = repo_link
             parsed_url = urlparse(current_repo_link)
             hostname = parsed_url.hostname
 
             if hostname and hostname in ['www.github.com', 'github.com']:
-                return GitHubImporter(current_repo_link, src_json_file_path)
+                return GitHubImporter(current_repo_link, loaded_json_data)
             else:
                 raise SiteNotSupported(hostname)
         except SiteNotSupported as error:


### PR DESCRIPTION
- Added `sync` subcommand to allow syncing of labels from source repository to destination repository
- Optimised importing of `GitHub` labels logic in `github_importer.py` through concurrency
- Refactored `base_importer.py` and `github_importer.py` where `src_json_file_path` parameter is replaced with `loaded_json_data` parameter for improved cohesion and improved reusability