### PR TITLE
Amended `Readme.md` with installation instructions and examples on how to use the different subcommands available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,4 @@ fabric.properties
 
 # My custom .gitignore
 .idea/
+exported/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# Introduction
+# RepoLabels command line interface
+
+<a target="_blank" href="https://www.python.org/downloads/" title="Python Version Requirement"><img src="https://img.shields.io/badge/Python-%3E=_3.9.5-blue.svg"></a>
+<a target="_blank" href="[LICENSE](https://github.com/lwhjon/repo-labels-cli/blob/master/LICENSE)" title="MIT License"><img src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
+
+## Introduction
 
 **RepoLabels** is a GitHub Repository Labels command line interface which allows for easy exporting and importing of GitHub Labels.
 
-# Purpose
+## Purpose
 
 The purpose of this project includes:
 
@@ -10,22 +15,22 @@ The purpose of this project includes:
 - Serving as a practice for me to learn Python
 - The usage of public APIs such as [GitHub API](https://docs.github.com/en/rest)
 
-# What are the use cases of RepoLabels?
+## What are the use cases of RepoLabels?
 
 You can use **RepoLabels** to:
 
 - Backup your GitHub labels.
 - Import your GitHub labels to a different GitHub Repository.
 
-## Benefits
+### Benefits
 
 - This avoids users having to manually reconfigure their labels when creating a new GitHub Repository or when planning to synchronise the labels of an existing repository which helps to save development time.
 
-# Getting Started
+## Getting Started
 
 A brief description on how to get your copy of **RepoLabels** running.
 
-## Requirements
+### Requirements
 
 We recommend using Python `3.9.5` (or later)
 
@@ -33,7 +38,7 @@ We recommend using Python `3.9.5` (or later)
 
 Please refer to the [`requirements.txt`](https://github.com/lwhjon/repo-labels-cli/blob/master/requirements.txt) for the updated Python packages dependencies.
 
-## Installation
+### Installation
 
 1. Clone the **RepoLabels**'s GitHub Repository.
 2. Create a `.env` file in the project root directory with the structure as shown below.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PERSONAL_ACCESS_TOKEN
      - In the example below, we attempt to `import` the labels from the `json` file we obtained from the `export` subcommand example above to a sample repository:
 
        ```Shell
-       python import https://github.com/JonathanLeeWH/Sample exported/github_docs_2021_06_27_19_20_50_283179.json
+       python import exported/github_docs_2021_06_27_19_20_50_283179.json https://github.com/JonathanLeeWH/Sample
        ```
 
 _If you want to deactivate your current virtual environment, type `deactivate` in your command line or terminal._

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Python Version Requirement](https://img.shields.io/badge/Python-%3E=_3.9.5-blue)](https://www.python.org/downloads/)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue)](https://github.com/lwhjon/repo-labels-cli/blob/master/LICENSE)
+[![Latest Stable Version)](https://img.shields.io/github/v/release/lwhjon/repo-labels-cli?color=blue&label=Latest%20Stable%20Version)](https://github.com/lwhjon/repo-labels-cli/releases)
+[![Latest Version including pre-releases)](https://img.shields.io/github/v/release/lwhjon/repo-labels-cli?color=blue&include_prereleases&label=Latest%20Version%20%28including%20pre%20releases%29)](https://github.com/lwhjon/repo-labels-cli/releases)
+
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RepoLabels command line interface
 
-<a target="_blank" href="https://www.python.org/downloads/" title="Python Version Requirement"><img src="https://img.shields.io/badge/Python-%3E=_3.9.5-blue.svg"></a>
-<a target="_blank" href="[LICENSE](https://github.com/lwhjon/repo-labels-cli/blob/master/LICENSE)" title="MIT License"><img src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
+[![Python Version Requirement](https://img.shields.io/badge/Python-%3E=_3.9.5-blue)](https://www.python.org/downloads/)
+[![MIT License](https://img.shields.io/badge/License-MIT-blue)](https://github.com/lwhjon/repo-labels-cli/blob/master/LICENSE)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PERSONAL_ACCESS_TOKEN
        python import exported/github_docs_2021_06_27_19_20_50_283179.json https://github.com/JonathanLeeWH/Sample
        ```
 
+   - To check the current `ratelimit` for each services such as GitHub API ratelimit.
+      ```Shell
+       python ratelimit
+       ```
+
 _If you want to deactivate your current virtual environment, type `deactivate` in your command line or terminal._
 
 ## Technologies and Frameworks

--- a/README.md
+++ b/README.md
@@ -1,40 +1,104 @@
-# RepoLabels command line interface
+# Introduction
+
 **RepoLabels** is a GitHub Repository Labels command line interface which allows for easy exporting and importing of GitHub Labels.
 
+# Purpose
+
+The purpose of this project includes:
+
+- Creating a tool which helps automate synchronisation of GitHub Labels for my personal usage and [use cases](#what-are-the-use-cases-of-repolabels).
+- Serving as a practice for me to learn Python
+- The usage of public APIs such as [GitHub API](https://docs.github.com/en/rest)
+
 # What are the use cases of RepoLabels?
+
 You can use **RepoLabels** to:
-- Backup your GitHub labels
+
+- Backup your GitHub labels.
 - Import your GitHub labels to a different GitHub Repository.
 
 ## Benefits
-- This avoids users having to manually reconfigure your labels when creating a new GitHub Repository or when planning to synchronise the labels of an existing repository. 
+
+- This avoids users having to manually reconfigure their labels when creating a new GitHub Repository or when planning to synchronise the labels of an existing repository which helps to save development time.
 
 # Getting Started
+
 A brief description on how to get your copy of **RepoLabels** running.
 
 ## Requirements
-We recommend using Python `3.9.5` (or the latest Python version)
+
+We recommend using Python `3.9.5` (or later)
 
 **Python packages dependencies**
 
 Please refer to the [`requirements.txt`](https://github.com/lwhjon/repo-labels-cli/blob/master/requirements.txt) for the updated Python packages dependencies.
 
 ## Installation
-1. Open your command line or terminal and go to the directory where you installed **RepoLabelsp**.
-2. Create a virtual environment in Python in the directory of where **RepoLabels** is located.
-   *  `python -m venv <name_of_virtual_env>`
-3. Activate the newly created virtual environment.
-   * `<name_of_virtual_env>\Scripts\activate.bat` **(Windows)**
-   * `<name_of_virtual_env>/bin/activate` **(Linux/Mac)**
-4. Install the necessary Python package dependencies using the [`requirements.txt`](https://github.com/lwhjon/repo-labels-cli/blob/master/requirements.txt) included by **RepoLabels**
-   * `pip install -r requirements.txt` 
-5. You can now use **RepoLabels**.
-   * `python repolabels.py`
 
-*If you want to deactivate your current virtual environment, you can just type `deactivate` in your command line or terminal.*
+1. Clone the **RepoLabels**'s GitHub Repository.
+2. Create a `.env` file in the project root directory with the structure as shown below.
 
-# Purpose
-The purpose of this project includes:
-- Creating a tool which helps automate synchronisation of GitHub Labels for my personal usage and [use cases](#what-are-the-use-cases-of-repolabels).
-- Serving as a practice for me to learn Python
-- The usage of public APIs such as [GitHub API](https://docs.github.com/en/rest)
+Sample `.env` file ([.env.sample](https://github.com/lwhjon/repo-labels-cli/blob/master/.env.example))
+
+```Shell
+# GitHub credentials
+# Please refer to our documentation or GitHub documentation on how to retrieve your GitHub Personal Access Token.
+# Resources:
+# https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token
+GITHUB_USERNAME=YOUR_GITHUB_USERNAME
+GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PERSONAL_ACCESS_TOKEN
+```
+
+**Note:** Please ensure that you key in all your desired values for the respective fields in the `.env` file.
+
+3. Open your favourite terminal/command prompt in the **RepoLabels**'s working directory.
+4. Create a virtual environment in Python in the directory of where **RepoLabels** is located.
+   - `python -m venv <name_of_virtual_env>`
+5. Activate the newly created virtual environment.
+   - `<name_of_virtual_env>\Scripts\activate.bat` **(Windows)**
+   - `<name_of_virtual_env>/bin/activate` **(Linux/Mac)**
+6. Install the necessary Python package dependencies using the [`requirements.txt`](https://github.com/lwhjon/repo-labels-cli/blob/master/requirements.txt) included by **RepoLabels**
+   - `pip install -r requirements.txt`
+7. You can now use **RepoLabels**.
+   - To view the list of available commands: `python repolabels.py --help`
+8. A sample list of subcommands:
+
+   - To `sync` labels from a GitHub Repository to another GitHub Repository
+
+     - In the example below, we attempt to sync the labels from [https://github.com/github/docs](https://github.com/github/docs)'s GitHub Repository to a sample GitHub Repository:
+
+       ```Shell
+       python repolabels.py sync https://github.com/github/docs https://github.com/JonathanLeeWH/Sample
+       ```
+
+   - To `export` labels from a GitHub Repository to a `json` format compatible with **RepoLabels**
+
+     - In the example below, we attempt to `export` the labels from [https://github.com/github/docs](https://github.com/github/docs)'s GitHub Repository:
+
+       ```Shell
+       python repolabels.py export https://github.com/github/docs
+       ```
+
+       **Note:** By default, the `json` file will be exported to `exported/{repo_owner}_{repo_name}_{current date and time}.json`
+
+       In the example above, the `json` file exported is located in `exported/github_docs_2021_06_27_19_20_50_283179.json`
+
+       You can **change the export destination file path** using the `-d` flag followed by your desired destination file path.
+
+   - To `import` labels from a `json` format compatible with **RepoLabels** to a sample GitHub Repository.
+
+     - In the example below, we attempt to `import` the labels from the `json` file we obtained from the `export` subcommand example above to a sample repository:
+
+       ```Shell
+       python import https://github.com/JonathanLeeWH/Sample exported/github_docs_2021_06_27_19_20_50_283179.json
+       ```
+
+_If you want to deactivate your current virtual environment, type `deactivate` in your command line or terminal._
+
+## Technologies and Frameworks
+
+A list of the technologies and frameworks used in this project
+
+### APIs
+
+- [GitHub API](https://docs.github.com/en/rest)

--- a/extractors/base_extractor.py
+++ b/extractors/base_extractor.py
@@ -12,6 +12,10 @@ class BaseExtractor(ABC):
         self.repo_name = None
 
     @abstractmethod
+    def get_rate_limit(self):
+        raise NotImplementedError
+
+    @abstractmethod
     def request_labels(self):
         raise NotImplementedError
 

--- a/extractors/github_extractor.py
+++ b/extractors/github_extractor.py
@@ -24,7 +24,7 @@ class GitHubExtractor(BaseExtractor):
         super().__init__(link)
         self.main_api_link = 'https://api.github.com'
         self.accept_header = 'application/vnd.github.v3+json'
-        # Max number of pages allowed by GitHub API for list of labels in repository is 100
+        # Max number of labels per page allowed by GitHub API for retrieval of the list of labels in repository is 100
         # https://docs.github.com/en/rest/reference/issues#list-labels-for-a-repository
         self.per_page = 100
         self.total_num_pages_labels = None

--- a/repolabels.py
+++ b/repolabels.py
@@ -9,7 +9,7 @@ import sys
 import logging
 
 from pathlib import Path
-from utilities.cli_utils import open_link, run_extractor, format_url, run_importer, rate_limits
+from utilities.cli_utils import open_link, run_extractor, format_url, run_importer, rate_limits, validate_url
 from datetime import datetime
 
 SOFTWARE_NAME = "Repository Labels command line interface"
@@ -90,6 +90,8 @@ def main():
 
     # The logic for "sync" subcommand
     if hasattr(args, 'sync_src_repo_link') and hasattr(args, 'sync_dest_repo_link'):
+        validate_url(args.sync_src_repo_link)
+        validate_url(args.sync_dest_repo_link)
         current_src_repo_url = format_url(args.sync_src_repo_link)
         current_dest_repo_url = format_url(args.sync_dest_repo_link)
 
@@ -106,6 +108,8 @@ def main():
 
     # The logic for "export" subcommand
     if hasattr(args, 'export_cmd_repo_link'):
+        validate_url(args.export_cmd_repo_link)
+
         current_export_url = format_url(args.export_cmd_repo_link)
 
         current_extractor = run_extractor(current_export_url)
@@ -136,6 +140,7 @@ def main():
             logger.debug("The data read from json file:", loaded_json_data)
 
             if loaded_json_data:
+                validate_url(args.import_cmd_repo_link)
                 current_import_url = format_url(args.import_cmd_repo_link)
 
                 current_importer = run_importer(current_import_url, loaded_json_data)

--- a/repolabels.py
+++ b/repolabels.py
@@ -63,10 +63,10 @@ def main():
     parser_import = subparsers.add_parser('import',
                                           help="Import labels from a compatible json file constructed from "
                                                "the 'export' subcommand to the repository.")
-    parser_import.add_argument('import_cmd_repo_link',
-                               help="Link to the repository in which the labels are to be imported to.")
     parser_import.add_argument('src_json_file_path', type=Path,
                                help="The source json file path in which the labels will be imported from.")
+    parser_import.add_argument('import_cmd_repo_link',
+                               help="Link to the repository in which the labels are to be imported to.")
 
     # Parser for "website" subcommand
     parser_website = subparsers.add_parser('website', help=f'Redirects to the {SOFTWARE_NAME} project website')

--- a/repolabels.py
+++ b/repolabels.py
@@ -9,7 +9,7 @@ import sys
 import logging
 
 from pathlib import Path
-from utilities.cli_utils import open_link, run_extractor, format_url, run_importer
+from utilities.cli_utils import open_link, run_extractor, format_url, run_importer, rate_limits
 from datetime import datetime
 
 SOFTWARE_NAME = "Repository Labels command line interface"
@@ -67,6 +67,11 @@ def main():
                                help="The source json file path in which the labels will be imported from.")
     parser_import.add_argument('import_cmd_repo_link',
                                help="Link to the repository in which the labels are to be imported to.")
+
+    # Parser for "ratelimit" subcommand
+    parser_rate_limit = subparsers.add_parser('ratelimit',
+                                              help="Retrieves the rate limit information for each services")
+    parser_rate_limit.set_defaults(rate_limit_func=rate_limits)
 
     # Parser for "website" subcommand
     parser_website = subparsers.add_parser('website', help=f'Redirects to the {SOFTWARE_NAME} project website')
@@ -140,6 +145,10 @@ def main():
                     logger.info(
                         f'Labels from {args.src_json_file_path} have been successfully imported '
                         f'to {args.import_cmd_repo_link}')
+
+    # The logic for "ratelimit" subcommand
+    if hasattr(args, 'rate_limit_func'):
+        args.rate_limit_func()
 
     logger.info("Script execution completed")
 

--- a/utilities/cli_utils.py
+++ b/utilities/cli_utils.py
@@ -8,7 +8,9 @@ import os
 import webbrowser
 
 from pathlib import Path
+from urllib.error import URLError
 from urllib.parse import urlparse
+from urllib.request import urlopen
 from utilities.extractor_facade import ExtractorFacade
 from utilities.importer_facade import ImporterFacade
 
@@ -91,3 +93,17 @@ def rate_limits(services=DEFAULT_SERVICES):
                    f"Total Rate Limit used: {rate_limit_used}\n" \
                    f"{service_name} API Rate Limit resets at {rate_limit_reset_time}\n"
         logger.info(f'Rate Limits Information: {response}')
+
+
+def validate_url(url):
+    """
+    To check if the internet connection is present and that the input url is valid else an error will be outputted
+    and the program exits with exit code 1.
+    :param url: The input url to be validated.
+    :return:
+    """
+    try:
+        urlopen(format_url(url), timeout=8)
+    except (URLError, ValueError):
+        logger.error(f'Please ensure that {url} is a valid url and that you are connected to the internet.')
+        raise SystemExit(1)


### PR DESCRIPTION
- Amended `Readme.md` with installation instructions and examples on how to use the different subcommands available
- Added `ratelimit` subcommand with GitHub API support
- Added input `url` validation which also checks that internet connection is available
- Amended `Readme.md` to include badges for the latest stable version and latest version including pre releases
- Amended `.gitignore` to include `exported/` directory which is the default `export` directory location used by `RepoLabels`
- Amended `Readme.md` with ratelimit subcommand information