### PR TITLE
Added `rm-all` subcommand to remove all labels from the input GitHub Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PERSONAL_ACCESS_TOKEN
    - To view the list of available commands: `python repolabels.py --help`
 8. A sample list of subcommands:
 
-   - The `sync` subcommand can be used to `sync` labels from a GitHub Repository to another GitHub Repository
+   - The `sync` subcommand can be used to `sync` labels from a GitHub Repository to another GitHub Repository.
 
      - In the example below, we attempt to sync the labels from [https://github.com/github/docs](https://github.com/github/docs)'s GitHub Repository to a sample GitHub Repository:
 
@@ -84,7 +84,7 @@ GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PERSONAL_ACCESS_TOKEN
        python repolabels.py sync https://github.com/github/docs https://github.com/JonathanLeeWH/Sample
        ```
 
-   - The `export` subcommand can be used to `export` labels from a GitHub Repository to a `json` format compatible with **RepoLabels**
+   - The `export` subcommand can be used to `export` labels from a GitHub Repository to a `json` format compatible with **RepoLabels**.
 
      - In the example below, we attempt to `export` the labels from [https://github.com/github/docs](https://github.com/github/docs)'s GitHub Repository:
 
@@ -104,6 +104,14 @@ GITHUB_PERSONAL_ACCESS_TOKEN=YOUR_GITHUB_PERSONAL_ACCESS_TOKEN
 
        ```Shell
        python repolabels.py import exported/github_docs_2021_06_27_19_20_50_283179.json https://github.com/JonathanLeeWH/Sample
+       ```
+
+   - The `rm-all` subcommand can be used to remove all the labels from a GitHub Repository.
+
+     - In the example below, we attempt to remove all the labels from a sample GitHub Repository:
+
+       ```Shell
+       python repolabels.py rm-all https://github.com/JonathanLeeWH/Sample
        ```
 
    - The `rate-limit` subcommand can be used to check the current rate limits for each services such as GitHub API rate limits.

--- a/importers/base_importer.py
+++ b/importers/base_importer.py
@@ -3,6 +3,8 @@ This module contains the BaseImporter Abstract class which all other importers a
 """
 from abc import ABC, abstractmethod
 
+from utilities.constants import ImportModes
+
 
 class BaseImporter(ABC):
 
@@ -17,5 +19,5 @@ class BaseImporter(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def execute(self):
+    def execute(self, mode: ImportModes):
         raise NotImplementedError

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class ImportModes(Enum):
+    IMPORT_LABELS = 'IMPORT'
+    DEL_ALL_LABELS = 'DEL_ALL_LABELS'


### PR DESCRIPTION
- Added `rm-all` subcommand to remove all labels from the input GitHub Repository
- Amended `Readme.md` with `rm-all` subcommand documentation
- Added `constants.py` with `ImportModes` enum for different import modes
- Amended `github_importer.py`'s `execute` method logic with support for different import modes