### PR TITLE
Improved GitHub Actions with support for build in `pip` dependency caching using latest dependency caching support without using a separate `cache` GitHub Actions workflow

### DIFF
--- a/.github/workflows/app-test.yml
+++ b/.github/workflows/app-test.yml
@@ -15,20 +15,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up latest Python 3
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          # This path is specific to Ubuntu
-          path: ~/.cache/pip
-          # Look to see if there is a cache hit for the corresponding requirements file
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+          python-version: '3.x'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
- Improved GitHub Actions with support for build in `pip` dependency caching using latest dependency caching support without using a separate `cache` GitHub Actions workflow

On 23 November 2021, it was announced that GitHub Actions `setup-python` supports build in dependency caching hence, we no longer require to use another separate `cache` GitHub Actions to handle caching: [Link](https://github.blog/changelog/2021-11-23-github-actions-setup-python-now-supports-dependency-caching/)